### PR TITLE
[merge / 30-style-상세페이지-퍼블리싱-수정] :rotating_light:Fix tailwind 커스텀 CSS 수정(fontSize 중복 선언)

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -50,6 +50,9 @@ export default {
         "info-base": ["1rem", { lineHeight: "auto", fontWeight: "500" }], // 16px
         "info-sm": ["0.875rem", { lineHeight: "auto", fontWeight: "500" }], // 14px
         "input-base": ["1rem", { lineHeight: "auto", fontWeight: "600" }], // 16px
+
+        clamp: "clamp(30px, 4vw, 50px)",
+
       },
       boxShadow: {
         default: "0px 8px 18px 0px rgba(168, 178, 198, 0.45)",
@@ -84,9 +87,6 @@ export default {
           900: "#060606",
         },
         background: "#1E1E1E",
-      },
-      fontSize: {
-        clamp: "clamp(30px, 4vw, 50px)",
       },
       // 스켈레톤
       animation: {


### PR DESCRIPTION
이슈 : tailwind.config.js 커스텀 설정해둔 폰트 사이즈가 반영되지 않았던 문제
원인 : fontSize 객체가 중복 선언돼서 아래쪽에 선언된 clamp: "clamp(30px, 4vw, 50px)로 덮어써짐
해결 : 하나의 객체로 통일