### PR TITLE
[merge / 44-style-header-css-수정] :lipstick:Style 헤더 정렬 수정 / padding 미디어쿼리

### DIFF
--- a/src/components/header/Nav.tsx
+++ b/src/components/header/Nav.tsx
@@ -10,10 +10,10 @@ export default function Nav({ className, activeTab, onTabChange }: NavProps) {
   return (
     <div
       className={`
-      flex items-center justify-center w-[1440px]  ${className} px-11 
+      flex items-center justify-center w-full ${className} 
     `}
     >
-      <div className="flex justify-between w-full max-w-[1440px] ">
+      <div className="flex justify-between w-full ">
         {/* 로고 */}
         <button onClick={() => navigate("/movie")}>
           <img src={logo} alt="홈으로 가기" />

--- a/src/layout/RootLayout.tsx
+++ b/src/layout/RootLayout.tsx
@@ -20,7 +20,7 @@ export default function RootLayout() {
   return (
     <div className="relative flex flex-col items-center w-full min-h-screen bg-background">
       <header className="fixed top-0 left-0 z-50 w-full backdrop-blur-md">
-        <div className="mx-auto max-w-[1520px] px-10 py-5">
+        <div className="mx-auto max-w-[1520px] py-5 max-[1519px]:px-10">
           <Nav onTabChange={setActiveTab} activeTab={activeTab} />
         </div>
       </header>


### PR DESCRIPTION
✅ 목적
- padding값과 max-width 중복 제한으로 디자인 산출물과 다른 퍼블리싱을 수정함

[ 내용 ]
✔️ 헤더 내부에 중복으로 걸려있는 max-width 제거 ( components / header / Nav )
✔️ window 너비가 1519px 이하일 때만 padding값이 추가되도록 미디어쿼리 추가 ( layout / RootLayout )