### PR TITLE
[merge / 48-style-인물-컴포넌트-css-수정] :lipstick:Style Swiper 적용 / 컴포넌트 크기 조정

### DIFF
--- a/src/pages/details/DetailMovie.tsx
+++ b/src/pages/details/DetailMovie.tsx
@@ -7,6 +7,8 @@ import TrailerSwiper from "./components/TrailerSwiper";
 import CastList from "./components/CastList";
 import SimilarMovies from "./components/SimilarMovies";
 import { CastMember } from "./components/CastList";
+import DetailComment from "./components/DetailComment";
+import createComment from "../../assets/detailPage/paper-plane.svg";
 
 export default function DetailMovie() {
   const { id } = useParams();
@@ -31,8 +33,8 @@ export default function DetailMovie() {
           setMovieDetails(details);
           setVideos(movieVideos);
           setCast(castData);
-          const filteredSimilarMovies = similar.filter((movie : any) => movie.poster_path);
-        setSimilarMovies(filteredSimilarMovies);
+          const filteredSimilarMovies = similar.filter((movie: any) => movie.poster_path);
+          setSimilarMovies(filteredSimilarMovies);
         } catch (error) {
           console.error(error);
         } finally {
@@ -90,7 +92,7 @@ export default function DetailMovie() {
 
           {/* 하단 컨텐츠 */}
           <section className="relative mt-16 h-full bg-gradient-to-t from-[#1E1E1E] via-[#1E1E1E] via-65% to-transparent">
-            <figure className="p-8 relative z-10 w-full max-w-[1520px] mx-auto">
+            <figure className="max-[1519px]:p-8 relative z-10 w-full max-w-[1520px] mx-auto">
               <div className="flex justify-end mb-8 max-w-[1520px] mx-auto">
                 <DetailButtons
                   movieId={movieDetails?.id ?? 0}
@@ -106,13 +108,25 @@ export default function DetailMovie() {
                 </div>
               )}
             </figure>
-            {cast.length > 0 && <CastList cast={cast} />}
+            {cast.length > 0 && <CastList cast={cast} hasVideos={videos.length > 0} />}
             {similarMovies.length > 0 && <SimilarMovies movies={similarMovies} />}
-            <h2 className="text-white text-title-md">리뷰 남기기</h2>
-            <textarea
-              placeholder="타자를 두들길 준비 되셨나요? (｡･∀･)ﾉﾞ"
-              className="w-full max-w-[1520px] mx-auto min-h-10 rounded-2xl bg-[#F3F2F3]/10"
-            ></textarea>
+
+            {/* 댓글 작성 */}
+            <form className="w-full max-w-[1520px] mx-auto max-[1519px]:p-8">
+              <h2 className="pt-12 pb-6 text-white text-title-md">리뷰 남기기</h2>
+              <div className="relative">
+                <textarea
+                  placeholder="타자를 두들길 준비 되셨나요? (｡･∀･)ﾉﾞ"
+                  className="w-full min-h-40 rounded-2xl bg-[#F3F2F3]/10 p-4 text-white resize-none"
+                />
+                <button className="absolute transition-transform bottom-4 right-4 hover:scale-110">
+                  <img src={createComment} alt="댓글 작성" />
+                </button>
+              </div>
+            </form>
+
+            {/* 댓글 목록 */}
+            <DetailComment />
           </section>
         </section>
       </article>

--- a/src/pages/details/components/CastList.tsx
+++ b/src/pages/details/components/CastList.tsx
@@ -1,4 +1,8 @@
-// components/CastList.tsx
+import BaseSwiper from "../../../components/swiper/BaseSwiper";
+import getPersonImg from "../../../utils/getPersonImg";
+import { usePersonDetailModalStore } from "../../../store/PersonDetailModalStore";
+import { useEffect } from "react";
+
 export type CastMember = {
   id: number;
   name: string;
@@ -8,19 +12,13 @@ export type CastMember = {
 
 interface CastListProps {
   cast: CastMember[];
+  hasVideos?: boolean; // videos 유무를 전달받는 prop 추가
 }
 
-import getPersonImg from "../../../utils/getPersonImg";
-import { usePersonDetailModalStore } from "../../../store/PersonDetailModalStore";
-import { useEffect } from "react";
-
-export default function CastList({ cast }: CastListProps) {
-  // 15명까지만 필터링한 배열
+export default function CastList({ cast, hasVideos = true }: CastListProps) {
   const limitedCast = cast.slice(0, 15);
-
   const setIsPersonaDetailModaltrue = usePersonDetailModalStore((state) => state.setIsPersonaDetailModaltrue);
   const setIsPersonaDetailModalfalse = usePersonDetailModalStore((state) => state.setIsPersonaDetailModalfalse);
-
   const setPersonId = usePersonDetailModalStore((state) => state.setPersonId);
 
   useEffect(() => {
@@ -28,34 +26,69 @@ export default function CastList({ cast }: CastListProps) {
       setIsPersonaDetailModalfalse();
     };
   });
+
+  const renderCastMember = (member: CastMember) => (
+    <div
+      className="p-2 cursor-pointer"
+      onClick={() => {
+        setPersonId(member.id);
+        setIsPersonaDetailModaltrue();
+      }}
+    >
+      <div className="flex flex-col items-center">
+        <div className="w-full mb-4 overflow-hidden rounded-full aspect-square max-w-48">
+          {member.profile_path ? (
+            <img
+              src={`https://image.tmdb.org/t/p/w200${member.profile_path}`}
+              alt={member.name}
+              className="object-cover w-full h-full"
+            />
+          ) : (
+            <div className="w-full h-full">{getPersonImg()}</div>
+          )}
+        </div>
+        <p className="text-banner-text center text-main-100">{member.name}</p>
+        <p className="text-center text-gray-400 text-main-100/60 text-info-base">
+          {member.character}
+        </p>
+      </div>
+    </div>
+  );
+
   return (
-    <div className="pt-28 max-w-[1520px] m-auto bg-background">
-      <h2 className="mb-6 text-title-md text-white">출연진 / 감독</h2>
-      <div className="flex flex-wrap gap-6">
-        {limitedCast.map((member) => (
-          <div
-            key={member.id}
-            className="flex flex-col items-center w-32"
-            onClick={() => {
-              setPersonId(member.id);
-              setIsPersonaDetailModaltrue();
-            }}
-          >
-            <div className="w-32 h-32 mb-2 overflow-hidden rounded-full">
-              {member.profile_path ? (
-                <img
-                  src={`https://image.tmdb.org/t/p/w200${member.profile_path}`}
-                  alt={member.name}
-                  className="object-cover w-full h-full"
-                />
-              ) : (
-                <div className="w-full h-full">{getPersonImg()}</div>
-              )}
-            </div>
-            <p className="font-medium text-main-100 text-info-base">{member.name}</p>
-            <p className="text-gray-400 text-main-100 text-info-base">{member.character}</p>
-          </div>
-        ))}
+    <div className={`pt-28 max-w-[1520px] max-[1519px]:px-8 mx-auto ${
+      !hasVideos ? 'bg-gradient-to-t from-[#1E1E1E] via-[#1E1E1E]/10 via-5% to-transparent' : 'bg-background'
+    }`}>
+      <h2 className="mb-6 text-white text-title-md">출연진 / 감독</h2>
+      <div className="group">
+        <BaseSwiper
+          data={limitedCast}
+          renderItem={renderCastMember}
+          slidesPerView={5}
+          slidesPerGroup={5}
+          speed={800}
+          autoplay={false}
+          loop={false}
+          unique="cast-list"
+          navigate={true}
+        />
+        <style>
+          {`
+            .prev-cast-list,
+            .next-cast-list {
+              opacity: 0;
+              transition: opacity 0.3s ease;
+            }
+            .group:hover .prev-cast-list,
+            .group:hover .next-cast-list {
+              opacity: 1;
+            }
+            .swiper-button-prev,
+            .swiper-button-next {
+              color: white;
+            }
+          `}
+        </style>
       </div>
     </div>
   );

--- a/src/pages/details/components/DetailButtons.tsx
+++ b/src/pages/details/components/DetailButtons.tsx
@@ -67,11 +67,11 @@ export default function DetailButtons({
           <img
             src={`/src/assets/detailPage/${button.icon}`}
             alt={button.label}
-            className={`w-6 h-6 ${
+            className={`w-8 h-8 ${
               button.id === 'favorite' && isFavorite ? 'filter brightness-0 invert' : ''
             }`}
           />
-          <span className="text-sm text-white font-pretendard">{button.label}</span>
+          <span className="text-white text-info-sm font-pretendard">{button.label}</span>
         </button>
       ))}
     </div>

--- a/src/pages/details/components/DetailComment.tsx
+++ b/src/pages/details/components/DetailComment.tsx
@@ -1,0 +1,7 @@
+const DetailComment = () => {
+  return (
+    <article className="text-white">DetailComment</article>
+  )
+}
+
+export default DetailComment

--- a/src/pages/details/components/SimilarMovies.tsx
+++ b/src/pages/details/components/SimilarMovies.tsx
@@ -1,4 +1,12 @@
+import { Link } from "react-router-dom";
 import BaseSwiper from "../../../components/swiper/BaseSwiper";
+
+interface MovieItem {
+  id: number;
+  title: string;
+  poster_path: string;
+  release_date: string;
+}
 
 interface SimilarMoviesProps {
   movies: MovieItem[];
@@ -7,7 +15,10 @@ interface SimilarMoviesProps {
 export default function SimilarMovies({ movies }: SimilarMoviesProps) {
   // 각 영화 카드 렌더링 함수
   const renderMovie = (movie: MovieItem) => (
-    <div className="p-2">
+    <Link 
+      to={`/movie/${movie.id}`} 
+      className="block p-2 cursor-pointer"
+    >
       <div className="relative overflow-hidden rounded-3xl aspect-[2/3]">
         <img
           src={`https://image.tmdb.org/t/p/w500${movie.poster_path}`}
@@ -15,13 +26,17 @@ export default function SimilarMovies({ movies }: SimilarMoviesProps) {
           className="object-cover w-full h-full transition-transform duration-300 hover:scale-110"
         />
       </div>
-      <h3 className="mt-2 font-semibold text-white truncate text-info-lg">{movie.title}</h3>
-      <p className="text-info-base text-white/70">{new Date(movie.release_date).getFullYear()}</p>
-    </div>
+      <h3 className="mt-2 font-semibold text-white truncate text-info-lg">
+        {movie.title}
+      </h3>
+      <p className="text-info-base text-white/70">
+        {new Date(movie.release_date).getFullYear()}
+      </p>
+    </Link>
   );
 
   return (
-    <div className="w-full max-w-[1520px] mx-auto px-8 py-12">
+    <div className="w-full max-w-[1520px] mx-auto max-[1519px]:p-8 py-12">
       <h2 className="mb-6 text-2xl font-bold text-white">비슷한 영화 추천</h2>
       <BaseSwiper
         data={movies}


### PR DESCRIPTION
💄 Style
-  한 줄에 최대 5명까지만 출력
-  swiper 적용하기 (해당 swiper에 크기 맞추기)
-  배우 이름과 배역 이름 디자인 분리 → 배역 이름을 좀 더 연하게 변경

🚨 Fix
- 출연진 / 감독 배열에 값이 없을 때 컴포넌트가 렌더링되지 않도록 수정
- 트레일러 영상 배열에 값이 없을 경우 배경 단색 -> 그라데이션이 되도록 수정